### PR TITLE
[4] test if 3-level HMS breaks

### DIFF
--- a/pyhms/config.py
+++ b/pyhms/config.py
@@ -15,7 +15,7 @@ class BaseLevelConfig:
 
 
 class EALevelConfig(BaseLevelConfig):
-    def __init__(self, ea_class, pop_size, problem, bounds, lsc, generations, sample_std_dev=1.0, **kwargs) -> None:
+    def __init__(self, ea_class, pop_size, problem, bounds: np.ndarray, lsc, generations, sample_std_dev=1.0, **kwargs) -> None:
         super().__init__(problem, bounds, lsc)
         self.ea_class = ea_class
         self.pop_size = pop_size
@@ -25,7 +25,7 @@ class EALevelConfig(BaseLevelConfig):
 
 
 class DELevelConfig(BaseLevelConfig):
-    def __init__(self, pop_size, problem, bounds, lsc, generations, dither=False, scaling=0.8, crossover=0.9):
+    def __init__(self, pop_size, problem, bounds: np.ndarray, lsc, generations, dither=False, scaling=0.8, crossover=0.9):
         super().__init__(problem, bounds, lsc)
         self.pop_size = pop_size
         self.generations = generations
@@ -35,7 +35,7 @@ class DELevelConfig(BaseLevelConfig):
 
 
 class CMALevelConfig(BaseLevelConfig):
-    def __init__(self, problem, bounds, lsc, sigma0, generations, **kwargs) -> None:
+    def __init__(self, problem, bounds: np.ndarray, lsc, sigma0, generations, **kwargs) -> None:
         super().__init__(problem, bounds, lsc)
         self.sigma0 = sigma0
         self.generations = generations
@@ -43,7 +43,7 @@ class CMALevelConfig(BaseLevelConfig):
 
 
 class LocalOptimizationConfig(BaseLevelConfig):
-    def __init__(self, problem, bounds, lsc, method="L-BFGS-B", **kwargs) -> None:
+    def __init__(self, problem, bounds: np.ndarray, lsc, method="L-BFGS-B", **kwargs) -> None:
         super().__init__(problem, bounds, lsc)
         self.method = method
         self.__dict__.update(kwargs)

--- a/pyhms/sprout/sprout_mechanisms.py
+++ b/pyhms/sprout/sprout_mechanisms.py
@@ -46,9 +46,9 @@ class SproutMechanism:
         return candidates
 
 
-def get_NBC_sprout() -> SproutMechanism:
-    return SproutMechanism(NBC_Generator(2.0, 1.0), [NBC_FarEnough(2.0, 2), DemeLimit(1)], [LevelLimit(4)])
+def get_NBC_sprout(gen_dist_factor: float = 3.0, trunc_factor: float = 0.7, fil_dist_factor: float = 3.0, level_limit: int = 4) -> SproutMechanism:
+    return SproutMechanism(NBC_Generator(gen_dist_factor, trunc_factor), [NBC_FarEnough(fil_dist_factor, 2), DemeLimit(1)], [LevelLimit(level_limit)])
 
 
-def get_simple_sprout(far_enough: float, level_limit: float = 4) -> SproutMechanism:
+def get_simple_sprout(far_enough: float, level_limit: int = 4) -> SproutMechanism:
     return SproutMechanism(BestPerDeme(), [FarEnough(far_enough, 2)], [LevelLimit(level_limit)])

--- a/pyhms/tree.py
+++ b/pyhms/tree.py
@@ -75,11 +75,14 @@ class DemeTree:
             self.run_metaepoch()
             if not self._gsc(self):
                 self.run_sprout()
-            self._logger.info(
-                "Metaepoch finished",
-                best_fitness=max(self.optima).fitness,
-                best_individual=max(self.optima).genome,
-            )
+            if len(self.optima) > 0:
+                self._logger.info(
+                    "Metaepoch finished",
+                    best_fitness=max(self.optima).fitness,
+                    best_individual=max(self.optima).genome,
+                )
+            else:
+                self._logger.info("Metaepoch finished. No leaf demes yet.")
 
     def run_metaepoch(self):
         for _, deme in reversed(self.active_demes):
@@ -121,7 +124,7 @@ class DemeTree:
                 )
                 deme.add_child(child)
                 self._levels[target_level].append(child)
-                self._logger.debug("Sprouted new child", seed=child._seed.genome)
+                self._logger.debug("Sprouted new child", seed=child._seed.genome, id=new_id, tree_level=target_level)
 
     def _next_child_id(self, deme: EADeme) -> str:
         if deme.level >= self.height - 1:

--- a/test/config.py
+++ b/test/config.py
@@ -1,9 +1,14 @@
 from leap_ec.problem import FunctionProblem
-from pyhms.sprout import get_simple_sprout
+import numpy as np
+from pyhms.sprout import get_simple_sprout, get_NBC_sprout
 from pyhms.stop_conditions.usc import metaepoch_limit
 
 SQUARE_PROBLEM = FunctionProblem(lambda x: sum(x**2), maximize=False)
+SQUARE_BOUNDS = np.array([(-20, 20), (-20, 20)])
 
 DEFAULT_GSC = metaepoch_limit(limit=10)
 
-DEFAULT_SPROUT_COND = get_simple_sprout(1.0)
+LEVEL_LIMIT = 4
+
+DEFAULT_SPROUT_COND = get_simple_sprout(1.0, level_limit=LEVEL_LIMIT)
+DEFAULT_NBC_SPROUT_COND = get_NBC_sprout(level_limit=LEVEL_LIMIT)

--- a/test/test_more_levels.py
+++ b/test/test_more_levels.py
@@ -1,0 +1,92 @@
+import unittest
+
+from pyhms.config import DELevelConfig, CMALevelConfig, EALevelConfig, TreeConfig
+from pyhms.demes.single_pop_eas.sea import SEA
+from pyhms.stop_conditions.usc import dont_stop
+from pyhms.tree import DemeTree
+
+from .config import DEFAULT_GSC, DEFAULT_SPROUT_COND, DEFAULT_NBC_SPROUT_COND, SQUARE_PROBLEM, SQUARE_BOUNDS, LEVEL_LIMIT
+
+class Test3Levels(unittest.TestCase):
+    def test_with_simple_sprout(self):
+        options = {"log_level": "debug"}
+        levels = [
+            DELevelConfig(
+                generations=2,
+                problem=SQUARE_PROBLEM,
+                bounds=SQUARE_BOUNDS,
+                pop_size=20,
+                dither=True,
+                crossover=0.9,
+                lsc=dont_stop(),
+            ),
+            EALevelConfig(
+                ea_class=SEA,
+                generations=2,
+                problem=SQUARE_PROBLEM,
+                bounds=SQUARE_BOUNDS,
+                pop_size=20,
+                mutation_std=1.0,
+                lsc=dont_stop(),
+            ),
+            CMALevelConfig(
+                generations=4,
+                problem=SQUARE_PROBLEM,
+                bounds=SQUARE_BOUNDS,
+                sigma0=2.5,
+                lsc=dont_stop(),
+            ),
+        ]
+        tree_config = TreeConfig(
+            levels=levels,
+            gsc=DEFAULT_GSC,
+            sprout_mechanism=DEFAULT_SPROUT_COND,
+            options=options,
+        )
+
+        deme_tree = DemeTree(tree_config)
+        deme_tree.run()
+        for level in deme_tree.levels:
+            self.assertTrue(len([deme for deme in level if deme.is_active]) <= LEVEL_LIMIT)
+
+
+    def test_with_NBC_sprout(self):
+        options = {"log_level": "debug"}
+        levels = [
+            DELevelConfig(
+                generations=2,
+                problem=SQUARE_PROBLEM,
+                bounds=SQUARE_BOUNDS,
+                pop_size=20,
+                dither=True,
+                crossover=0.9,
+                lsc=dont_stop(),
+            ),
+            EALevelConfig(
+                ea_class=SEA,
+                generations=2,
+                problem=SQUARE_PROBLEM,
+                bounds=SQUARE_BOUNDS,
+                pop_size=20,
+                mutation_std=1.0,
+                lsc=dont_stop(),
+            ),
+            CMALevelConfig(
+                generations=4,
+                problem=SQUARE_PROBLEM,
+                bounds=SQUARE_BOUNDS,
+                sigma0=2.5,
+                lsc=dont_stop(),
+            ),
+        ]
+        tree_config = TreeConfig(
+            levels=levels,
+            gsc=DEFAULT_GSC,
+            sprout_mechanism=DEFAULT_SPROUT_COND,
+            options=options,
+        )
+
+        deme_tree = DemeTree(tree_config)
+        deme_tree.run()
+        for level in deme_tree.levels:
+            self.assertTrue(len([deme for deme in level if deme.is_active]) <= LEVEL_LIMIT)


### PR DESCRIPTION
Tests show that 3-level HMS is functional and behaves accordingly with sprout filter limits. Testing it's overall viability and perforemence is other issue. Few features led to erroneous behaviour: logging optimas when there was no leaf demes and passing a list as bounds (np.NDarrays are typehinted for every config but the error occurs only for Differential Evolution demes due to numpy specific indexing used there)