### PR TITLE
fix: NBC Far Enough should work for local method

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [5]: https://pypi.python.org/pypi/pyhms "Pypi site"
 [6]: https://img.shields.io/pypi/pyversions/pyhms.svg
 [7]: https://github.com/agh-a2s/pyhms
-[8]: https://img.shields.io/github/license/agh-a2s/pyhms 
+[8]: https://img.shields.io/github/license/agh-a2s/pyhms
 
 `pyhms` is a Python implementation of Hierarchic Memetic Strategy (HMS).
 

--- a/pyhms/sprout/sprout_filters.py
+++ b/pyhms/sprout/sprout_filters.py
@@ -64,9 +64,6 @@ class NBC_FarEnough(DemeLevelCandidatesFilter):
         candidates: dict[AbstractDeme, DemeCandidates],
         tree,
     ) -> dict[AbstractDeme, DemeCandidates]:
-        assert all(
-            [cand.features.nbc_mean_distance is not None for cand in candidates.values()]
-        ), "NBC_FarEnough filter requires nbc_mean_distance feature in candidates added through NBC_Generator"
         for deme in candidates.keys():
             child_siblings = [sibling for sibling in tree.levels[deme.level + 1] if sibling.is_active]
             child_seeds = candidates[deme].individuals
@@ -74,7 +71,12 @@ class NBC_FarEnough(DemeLevelCandidatesFilter):
                 child_seeds = [
                     ind
                     for ind in child_seeds
-                    if self._is_nbc_far_enough(ind, sibling.centroid, candidates[deme].features.nbc_mean_distance)
+                    if candidates[deme].features.nbc_mean_distance is None
+                    or self._is_nbc_far_enough(
+                        ind,
+                        sibling.centroid,
+                        candidates[deme].features.nbc_mean_distance,
+                    )
                 ]
             candidates[deme].individuals = child_seeds
         return candidates

--- a/pyhms/sprout/sprout_filters.py
+++ b/pyhms/sprout/sprout_filters.py
@@ -64,6 +64,9 @@ class NBC_FarEnough(DemeLevelCandidatesFilter):
         candidates: dict[AbstractDeme, DemeCandidates],
         tree,
     ) -> dict[AbstractDeme, DemeCandidates]:
+        assert all(
+            [cand.features.nbc_mean_distance is not None for cand in candidates.values()]
+        ), "NBC_FarEnough filter requires nbc_mean_distance feature in candidates added through NBC_Generator"
         for deme in candidates.keys():
             child_siblings = [sibling for sibling in tree.levels[deme.level + 1] if sibling.is_active]
             child_seeds = candidates[deme].individuals
@@ -71,8 +74,7 @@ class NBC_FarEnough(DemeLevelCandidatesFilter):
                 child_seeds = [
                     ind
                     for ind in child_seeds
-                    if candidates[deme].features.nbc_mean_distance is None
-                    or self._is_nbc_far_enough(
+                    if self._is_nbc_far_enough(
                         ind,
                         sibling.centroid,
                         candidates[deme].features.nbc_mean_distance,

--- a/pyhms/sprout/sprout_generators.py
+++ b/pyhms/sprout/sprout_generators.py
@@ -69,5 +69,9 @@ class NBCGeneratorWithLocalMethod(SproutCandidatesGenerator):
                     )
         for deme in tree.levels[-2]:
             if not deme.is_active and deme.started_at + len(deme.history) == tree.metaepoch_count:
-                candidates[deme] = DemeCandidates(individuals=[deme.best_individual], features=DemeFeatures())
+                candidates[deme] = DemeCandidates(
+                    individuals=[deme.best_individual],
+                    # Use 0.0 to make sure that it works with the NBC_FarEnough filter.
+                    features=DemeFeatures(nbc_mean_distance=0.0),
+                )
         return candidates  # type: ignore[return-value]


### PR DESCRIPTION
This assert:
```
assert all(
            [cand.features.nbc_mean_distance is not None for cand in candidates.values()]
        ), "NBC_FarEnough filter requires nbc_mean_distance feature in candidates added through NBC_Generator"
```
assumes that we can't mix NBC_Generator with BestPerDeme, I don't like this assumption. We should enable it especially for local methods.