### PR TITLE
feat: add new MahalanobisFarEnough sprout filter

### DIFF
--- a/pyhms/cluster/cluster.py
+++ b/pyhms/cluster/cluster.py
@@ -2,12 +2,7 @@ import numpy as np
 
 from ..core.population import Population
 from ..demes.cma_deme import CMADeme
-
-
-def mahalanobis_distance(x: np.ndarray, y: np.ndarray, covariance_matrix_inverse: np.ndarray) -> float:
-    diff = x - y
-    return np.sqrt(diff @ covariance_matrix_inverse @ diff)
-
+from ..utils.distances import mahalanobis_distance
 
 DEFAULT_CLUSTER_SIZE = 30
 

--- a/pyhms/sprout/__init__.py
+++ b/pyhms/sprout/__init__.py
@@ -1,3 +1,3 @@
-from .sprout_filters import DemeLimit, FarEnough, LevelLimit, NBC_FarEnough, SkipSameSprout
+from .sprout_filters import DemeLimit, FarEnough, LevelLimit, MahalanobisFarEnough, NBC_FarEnough, SkipSameSprout
 from .sprout_generators import BestPerDeme, NBC_Generator, NBCGeneratorWithLocalMethod
 from .sprout_mechanisms import SproutMechanism, get_NBC_sprout, get_simple_sprout

--- a/pyhms/utils/distances.py
+++ b/pyhms/utils/distances.py
@@ -1,0 +1,19 @@
+from scipy.stats import chi2
+import numpy as np
+
+
+def calculate_chi_squared_threshold(percentile: float, dimensions: int) -> float:
+    """
+    Calculate the threshold for the Mahalanobis distance using the chi-squared distribution.
+    """
+    if not 0 < percentile < 1:
+        raise ValueError("Percentile must be between 0 and 1")
+
+    return chi2.ppf(percentile, df=dimensions)
+
+
+def mahalanobis_distance(
+    x: np.ndarray, y: np.ndarray, covariance_matrix_inverse: np.ndarray
+) -> float:
+    diff = x - y
+    return np.sqrt(diff @ covariance_matrix_inverse @ diff)

--- a/pyhms/utils/distances.py
+++ b/pyhms/utils/distances.py
@@ -1,5 +1,5 @@
-from scipy.stats import chi2
 import numpy as np
+from scipy.stats import chi2
 
 
 def calculate_chi_squared_threshold(percentile: float, dimensions: int) -> float:
@@ -12,8 +12,6 @@ def calculate_chi_squared_threshold(percentile: float, dimensions: int) -> float
     return chi2.ppf(percentile, df=dimensions)
 
 
-def mahalanobis_distance(
-    x: np.ndarray, y: np.ndarray, covariance_matrix_inverse: np.ndarray
-) -> float:
+def mahalanobis_distance(x: np.ndarray, y: np.ndarray, covariance_matrix_inverse: np.ndarray) -> float:
     diff = x - y
     return np.sqrt(diff @ covariance_matrix_inverse @ diff)


### PR DESCRIPTION
TODO:
- [x] use chi^2 to find a good value for the default threshold.

### Statistical Distribution of Mahalanobis Distance:

When we have a multivariate normal distribution, the squared Mahalanobis distance follows a chi-squared distribution. This is a key property that links the Mahalanobis distance to the chi-squared distribution.

### Degrees of Freedom:

The chi-squared distribution we use has degrees of freedom equal to the number of dimensions (n) of our space. This is because each dimension contributes one degree of freedom to the distance calculation.

### Probability Contours:

In a multivariate normal distribution, the contours of equal probability form ellipsoids. These ellipsoids are defined by points of constant Mahalanobis distance from the mean. The chi-squared distribution allows us to determine the size of these ellipsoids for a given probability.

### Confidence Regions:

By choosing a particular percentile of the chi-squared distribution, we're effectively selecting a confidence region. For example, using the 95th percentile creates a region that, under the assumption of multivariate normality, should contain 95% of the points from the distribution.